### PR TITLE
add redirect to curl

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -12,7 +12,7 @@ list_all () {
   local versions=""
 
   releases_path=https://api.github.com/repos/k14s/${toolname}/releases
-  cmd="curl -s"
+  cmd="curl -Ls"
   if [ -n "${GITHUB_API_TOKEN}" ]; then
     cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
   fi


### PR DESCRIPTION
Today, no version is returned from the `list-all` command.

This PR adds a "follow redirect" optioon avoid this error with the current `curl -s`:
```
curl -s https://api.github.com/repos/k14s/kapp/releases 
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/175895515/releases",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```