### PR TITLE
Rename from k14s + Support arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# asdf-k14s [![test-all](https://github.com/k14s/asdf-k14s/workflows/test-all/badge.svg)](https://github.com/k14s/asdf-k14s/actions)
+# asdf-carvel [![test-all](https://github.com/vmware-tanzu/asdf-carvel/workflows/test-all/badge.svg)](https://github.com/vmware-tanzu/asdf-carvel/actions)
 
-k14s plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+carvel plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Install
 
 ```
-asdf plugin-add <ytt|kbld|kapp|kwt|vendir|imgpkg|json2k8s> https://github.com/k14s/asdf-k14s.git
+asdf plugin-add <ytt|kbld|kapp|kwt|vendir|imgpkg|json2k8s> https://github.com/vmware-tanzu/asdf-carvel.git
 ```
 
 ## Use
 
-Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage versions of tools from k14s.
+Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage versions of tools from carvel.
 
 ## Thanks!
 

--- a/bin/install
+++ b/bin/install
@@ -46,13 +46,31 @@ install () {
   fi
 }
 
-get_arch () {
+get_os () {
   uname | tr '[:upper:]' '[:lower:]'
 }
 
+get_arch () {
+  local -r arch="$(uname -m)"
+  case "${arch}" in
+    x86_64)
+      echo amd64
+      ;;
+    arm64|aarch64)
+      echo arm64
+      ;;
+    *)
+      # fallback: use machine's literal arch for download URL
+      # this helps this code be future-proof (ex: s390x)
+      echo "$arch"
+      ;;
+  esac
+}
+
 get_filename () {
-  local -r platform="$(get_arch)"
-  echo "${toolname}-${platform}-amd64"
+  local -r os="$(get_os)"
+  local -r arch="$(get_arch)"
+  echo "${toolname}-${os}-${arch}"
 }
 
 get_download_url() {

--- a/bin/install
+++ b/bin/install
@@ -58,7 +58,7 @@ get_filename () {
 get_download_url() {
   local -r version="$1"
   local -r filename="$(get_filename)"
-  echo "https://github.com/k14s/${toolname}/releases/download/v${version}/${filename}"
+  echo "https://github.com/vmware-tanzu/carvel-${toolname}/releases/download/v${version}/${filename}"
 }
 
 install "${ASDF_INSTALL_TYPE}" "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -11,7 +11,7 @@ readonly toolname="$(basename "$(dirname "${__dirname}")")"
 list_all () {
   local versions=""
 
-  releases_path=https://api.github.com/repos/k14s/${toolname}/releases
+  releases_path=https://api.github.com/repos/vmware-tanzu/carvel-${toolname}/releases
   cmd="curl -Ls"
   if [ -n "${GITHUB_API_TOKEN}" ]; then
     cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"


### PR DESCRIPTION
:)

Changes:
- Support arm64 + fallback to arbitrary architectures
- Rename k14s to carvel + Update links and release URLs